### PR TITLE
Add mutex to protect connections fixing a race condition

### DIFF
--- a/client.go
+++ b/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"sync"
 
 	"github.com/cenkalti/rpc2"
 	"github.com/cenkalti/rpc2/jsonrpc"
@@ -19,6 +20,8 @@ type OvsdbClient struct {
 
 func newOvsdbClient(c *rpc2.Client) *OvsdbClient {
 	ovs := &OvsdbClient{rpcClient: c, Schema: make(map[string]DatabaseSchema)}
+	connectionsMutex.Lock()
+	defer connectionsMutex.Unlock()
 	connections[c] = ovs
 	return ovs
 }
@@ -26,6 +29,7 @@ func newOvsdbClient(c *rpc2.Client) *OvsdbClient {
 // Would rather replace this connection map with an OvsdbClient Receiver scoped method
 // Unfortunately rpc2 package acts wierd with a receiver scoped method and needs some investigation.
 var connections map[*rpc2.Client]*OvsdbClient = make(map[*rpc2.Client]*OvsdbClient)
+var connectionsMutex = &sync.RWMutex{}
 
 const DEFAULT_ADDR = "127.0.0.1"
 const DEFAULT_PORT = 6640
@@ -107,6 +111,8 @@ type NotificationHandler interface {
 // RFC 7047 : Section 4.1.6 : Echo
 func echo(client *rpc2.Client, args []interface{}, reply *[]interface{}) error {
 	*reply = args
+	connectionsMutex.RLock()
+	defer connectionsMutex.RUnlock()
 	if _, ok := connections[client]; ok {
 		for _, handler := range connections[client].handlers {
 			handler.Echo(nil)
@@ -140,6 +146,8 @@ func update(client *rpc2.Client, params []interface{}, reply *interface{}) error
 
 	// Update the local DB cache with the tableUpdates
 	tableUpdates := getTableUpdatesFromRawUnmarshal(rowUpdates)
+	connectionsMutex.RLock()
+	defer connectionsMutex.RUnlock()
 	if _, ok := connections[client]; ok {
 		for _, handler := range connections[client].handlers {
 			handler.Update(params, tableUpdates)
@@ -245,6 +253,8 @@ func getTableUpdatesFromRawUnmarshal(raw map[string]map[string]RowUpdate) TableU
 }
 
 func clearConnection(c *rpc2.Client) {
+	connectionsMutex.Lock()
+	defer connectionsMutex.Unlock()
 	delete(connections, c)
 }
 


### PR DESCRIPTION
The connections map can be accessed from different goroutines at the same
time. For example handleDisconnectNotification which is modifying the map is
running in a different goroutine than the echo and update handlers which are
accessing the map. This leads in a race of the access to the map
connections. Thus calling the Diconnect func can trigger the same issue.

Running the test suite with the -race show the issue.

From https://github.com/socketplane/libovsdb/pull/37